### PR TITLE
Implement Bolding Adjacent Edges

### DIFF
--- a/client/src/app/grid-cell/grid-cell.component.ts
+++ b/client/src/app/grid-cell/grid-cell.component.ts
@@ -26,6 +26,10 @@ import { Edges } from './edges';
 export class GridCellComponent {
 
   @Input({ required: true }) gridCell: GridCell;
+  @Input({}) col: number;
+  @Input({}) row: number;
+  @Input({}) grid: GridCell[][];
+
 
   /**
    * Constructor for GridCellComponent.
@@ -85,15 +89,19 @@ export class GridCellComponent {
       switch (event.key) {
         case 'ArrowUp':
           this.gridCell.edges.top = !this.gridCell.edges.top;
+          this.grid[this.col][this.row - 1].edges.bottom = this.gridCell.edges.top;
           break;
         case 'ArrowRight':
           this.gridCell.edges.right = !this.gridCell.edges.right;
+          this.grid[this.col + 1][this.row].edges.left = this.gridCell.edges.right;
           break;
         case 'ArrowDown':
           this.gridCell.edges.bottom = !this.gridCell.edges.bottom;
+          this.grid[this.col][this.row + 1].edges.top = this.gridCell.edges.bottom;
           break;
         case 'ArrowLeft':
           this.gridCell.edges.left = !this.gridCell.edges.left;
+          this.grid[this.col - 1][this.row].edges.right = this.gridCell.edges.left;
           break;
         default:
           break;

--- a/client/src/app/grid-cell/grid-cell.component.ts
+++ b/client/src/app/grid-cell/grid-cell.component.ts
@@ -89,19 +89,27 @@ export class GridCellComponent {
       switch (event.key) {
         case 'ArrowUp':
           this.gridCell.edges.top = !this.gridCell.edges.top;
-          this.grid[this.col][this.row - 1].edges.bottom = this.gridCell.edges.top;
+          if (this.grid) {
+            this.grid[this.col][this.row - 1].edges.bottom = this.gridCell.edges.top;
+          }
           break;
         case 'ArrowRight':
           this.gridCell.edges.right = !this.gridCell.edges.right;
-          this.grid[this.col + 1][this.row].edges.left = this.gridCell.edges.right;
+          if (this.grid) {
+            this.grid[this.col + 1][this.row].edges.left = this.gridCell.edges.right;
+          }
           break;
         case 'ArrowDown':
           this.gridCell.edges.bottom = !this.gridCell.edges.bottom;
-          this.grid[this.col][this.row + 1].edges.top = this.gridCell.edges.bottom;
+          if (this.grid) {
+            this.grid[this.col][this.row + 1].edges.top = this.gridCell.edges.bottom;
+          }
           break;
         case 'ArrowLeft':
           this.gridCell.edges.left = !this.gridCell.edges.left;
-          this.grid[this.col - 1][this.row].edges.right = this.gridCell.edges.left;
+          if (this.grid) {
+            this.grid[this.col - 1][this.row].edges.right = this.gridCell.edges.left;
+          }
           break;
         default:
           break;

--- a/client/src/app/grid/grid.component.html
+++ b/client/src/app/grid/grid.component.html
@@ -15,11 +15,14 @@
           <mat-grid-tile Rowspan="1" Colspan="1" >
             <app-grid-cell
             tabindex= "0"
-            [gridCell]= ""
+            [gridCell]= "grid[colIndex][rowIndex]"
             (keydown)= "onKeydown($event, currentCol, currentRow)"
             (click)="onClick($event, colIndex, rowIndex)"
-            [attr.data-col]="colIndex"
-            [attr.data-row]="rowIndex"
+            [attr.col]="colIndex"
+            [attr.row]="rowIndex"
+            [col]="colIndex"
+            [row]="rowIndex"
+            [grid]="grid"
             [ngStyle]="{'height': m + 'px', 'width': m + 'px'}"
             ></app-grid-cell>
           </mat-grid-tile>

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -87,7 +87,7 @@ export class GridComponent {
    */
   onKeydown(event: KeyboardEvent, col: number, row: number) {
     const cell = this.grid[col][row];
-    const inputElement = this.elRef.nativeElement.querySelector(`app-grid-cell[data-col="${col}"][data-row="${row}"] input`);
+    const inputElement = this.elRef.nativeElement.querySelector(`app-grid-cell[col="${col}"][row="${row}"] input`);
 
     console.log('keydown', event.key, col, row);
 
@@ -175,7 +175,7 @@ export class GridComponent {
 
       console.log(col, row);
 
-      const cellInput = document.querySelector(`app-grid-cell[data-col="${col}"][data-row="${row}"] input`);
+      const cellInput = document.querySelector(`app-grid-cell[col="${col}"][row="${row}"] input`);
       console.log(cellInput);
 
       if (cellInput) {


### PR DESCRIPTION
In grid-component files, I changed how the grid is passing it's coordinates to the grid-cell component in order to let the cells be able to where they are in the grid. I also added an input to pass the grid to the grid-cells it contains.

In grid-cell-component.ts, I added functionality to bolding the adjacent edge by looking at the components grid and bolding the respective edges on keydown.